### PR TITLE
Minimal solution for cashed requests with wrong states

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1287,8 +1287,7 @@ def tests_finished(request):
 def tests_user(request):
     request.response.headerlist.extend(
         (
-            ("Cache-Control", "no-cache, no-store, must-revalidate"),
-            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-store"),
             ("Expires", "0"),
         )
     )
@@ -1342,8 +1341,7 @@ building = threading.Semaphore()
 def tests(request):
     request.response.headerlist.extend(
         (
-            ("Cache-Control", "no-cache, no-store, must-revalidate"),
-            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-store"),
             ("Expires", "0"),
         )
     )


### PR DESCRIPTION
this should in principle increase the performance of the back button load on the test pages, this minimal solution is dropping out cache control support of old legacy browsers while still unifying the back button mismatched behavior in different modern browsers

(feedback needed about dropping the extra parenthesis)